### PR TITLE
Update correct link for U.S. CMS.gov Design System

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Know a resource that isn't listed below? Feel free to create a new [pull request
 | [Ubuntu Brand Guidelines](http://design.ubuntu.com/)| 👍 | 👍 |  |  |
 | [USPTO UI Design Library](http://uspto.github.io/designpatterns/index.html) | 👍 |  | 👍 |  |
 | [U.S. Web Design Standards](https://standards.usa.gov/) | 👍 | 👍 | 👍 |  |
-| [U.S. CMS.gov Design System](https://standards.usa.gov/) | 👍 |  |  |  |
+| [U.S. CMS.gov Design System](https://design.cms.gov/) | 👍 |  |  |  |
 | [VMware {code}](https://code.vmware.com/) | 👍 |  |  |  |
 | [VMware Clarity Design System](https://vmware.github.io/clarity/) | 👍 | 👍 | 👍 |  |
 | [VMware UI Pattern Library](http://ui-patterns.vmware.com/) | 👍 |  | 👍 |  |


### PR DESCRIPTION
There was two same links for different titles. "U.S. Web Design Standards" and "U.S. CMS.gov Design System".