### PR TITLE
Fix link to predix-ui.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Know a resource that isn't listed below? Feel free to create a new [pull request
 | [PatternFly Open Interface Project](https://www.patternfly.org/) | 👍 | 👍 |  |  |
 | [Pivotal](http://styleguide.pivotal.io/) | 👍 |  |  |  |
 | [Pluralsight Design System](http://design-system.pluralsight.com/) | 👍 |  |  | 👍 |
-| [Predix Design System](https://wwww.predix-ui.com/) | 👍 |  |👍 |  |
+| [Predix Design System](https://www.predix-ui.com/) | 👍 |  |👍 |  |
 | [Pusher Chameleon](http://pusher.github.io/chameleon/) | 👍 |  |  |  |
 | [Rambler](https://rambler-digital-solutions.github.io/rambler-ui/) | 👍 |  |  | 👍 |
 | [Salesforce Lightning Design System](https://www.lightningdesignsystem.com) | 👍 | 👍 | 👍 |  |


### PR DESCRIPTION
Contained an extra w in the url. Corrected to www.predix-ui.com