### PR TITLE
Replace GOV.UK Service Manual with Design System

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Know a resource that isn't listed below? Feel free to create a new [pull request
 | [FutureLearn Pattern Library](https://www.futurelearn.com/pattern-library) | 👍 |  |  |  |
 | [GitHub Primer](http://primercss.io/) | 👍 |  |  | 👍 |
 | [Google Material Design](https://material.io/guidelines/#introduction-goals) | 👍 | 👍 | 👍 |  |
-| [GOV.UK Service Manual](https://www.gov.uk/service-manual) | 👍 |  |  |  |
+| [GOV.UK Design System](https://www.gov.uk/design-system) | 👍 |  |  |  |
 | [Help Scout](http://style.helpscout.com/) | 👍 | 👍 |  |  |
 | [Heroku Purple3](https://purple3.herokuapp.com/) | 👍 |  |  |  |
 | [Hewlett Packard grommet](https://grommet.github.io) | 👍 |  |  |  |


### PR DESCRIPTION
The GOV.UK Design System is now the home for the patterns that were previously found in the design section of the Service Manual, as well as the components that previously lived in GOV.UK Elements (not linked).