### PR TITLE
Stacks – Stack Overflow small updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Know a resource that isn't listed below? Feel free to create a new [pull request
 | [Seeds](https://sproutsocial.com/seeds)                                  |          | 👍             | 👍              |  |
 | [SEEK Style Guide](https://seek-oss.github.io/seek-style-guide/)                                  | 👍         |              |               | [:octocat:](https://github.com/seek-oss/seek-style-guide)            |
 | [Shopify Polaris](https://polaris.shopify.com)                                                    | 👍         | 👍           | 👍            | [:octocat:](https://github.com/Shopify/polaris)                      |
-| [Stack Exchange: Stacks UI](https://stackoverflow.design/)                                        | 👍         |              |               | [:octocat:](https://github.com/StackExchange/Stacks)                 |
+| [Stacks – Stack Overflow](https://stackoverflow.design/)                                        | 👍         | 👍           |               | [:octocat:](https://github.com/StackExchange/Stacks)                 |
 | [Starbucks Style Guide](https://www.starbucks.com/static/reference/styleguide/)                   | 👍         |              |               |                                                                      |
 | [Sky Toolkit](https://www.sky.com/toolkit)                                                        | 👍         |              |               | [:octocat:](https://github.com/sky-uk/toolkit)                       |
 | [The University of Melbourne Design System](https://web.unimelb.edu.au/)                          | 👍         |              |               | [:octocat:](https://github.com/unimelb/unimelb-design-system)        |


### PR DESCRIPTION
This PR fixes name for "Stacks" design system. What's currently in the table is incorrect in two places:

- Name – Stacks doesn't actually mention Stack Exchange, it's more related to Stack Overflow and I believe this is closer to how it's branded
- Voice & Tone – Stacks does indeed have [that section](https://stackoverflow.design/content/voice-and-tone)