### PR TITLE
Added link of System Design Roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Know a resource that isn't listed below? Feel free to create a new [pull request
 
 \*_Projects marked as open source may not always be open to use. Always check the license of these projects before using them._
 
-Although 'design systems', 'ui libraries', and 'pattern libraries' are different things, they are often used interchangeably. This list contains all three.
+Although 'design systems', 'ui libraries', and 'pattern libraries' are different things, they are often used interchangeably. This list contains all three. Moreover if you wish to have a step by step guide to system-design then visit [System Design Roadmap](https://roadmap.sh/system-design)
 
 ### Credits
 


### PR DESCRIPTION
Hi @alexpate,

I came across your repository [awesome-design-systems](https://github.com/alexpate/awesome-design-systems) and found it to be a valuable resource for System Design enthusiasts.

While browsing through the repository, I noticed that it was missing links to any structured guides such as the famous ["System Design Roadmap"](https://roadmap.sh/system-design). I took the initiative to submit a ["Pull Request"](https://github.com/alexpate/awesome-design-systems/pull/297) adding it in "Notes" section.

Thank you for your time and effort in maintaining this valuable resource :)

Best,
Mouaaz